### PR TITLE
Added support for Less Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ out (string):  path of CSS file to create
 sourcemap (bool): create sourcemap file
 compress (bool): compress CSS file
 main (string): path to your main LESS file to be compiled
+autoprefixer(string): value is passed as browsers to the autoprefixer-plugin, separate multiple entires with a ; character
+cleancss: value is passed as compatibility to the cleancss-plugin - not compatible with source-maps
 ```
 
 ## Example

--- a/lib/less-autocompile-view.coffee
+++ b/lib/less-autocompile-view.coffee
@@ -5,6 +5,8 @@ mkdirp   = require 'mkdirp'
 path     = require 'path'
 readline = require 'readline'
 
+lessPlugins = require './less-plugins'
+
 module.exports =
 class LessAutocompileView
   constructor: (serializeState) ->
@@ -71,6 +73,8 @@ class LessAutocompileView
       filename: path.basename params.file
       compress: if params.compress == 'true' then true else false
       sourceMap: if params.sourcemap == 'true' then {} else false
+
+    lessPlugins params, optionsLess
 
     rl = readline.createInterface
       input: fs.createReadStream params.file

--- a/lib/less-plugins.coffee
+++ b/lib/less-plugins.coffee
@@ -1,0 +1,26 @@
+module.exports =
+    (params, optionsLess) =>
+        optionsLess.plugins = []
+
+        if params.autoprefix
+            addAutoprefix params.autoprefix, optionsLess
+        if params.cleancss
+            addCleanCss params.cleancss, optionsLess
+
+addAutoprefix = (options, optionsLess) =>
+    AutoprefixLessPlugin = require 'less-plugin-autoprefix'
+
+    autoprefixOptions = {}
+    if typeof options == 'string'
+        autoprefixOptions.browsers = options.split ';'
+
+    optionsLess.plugins.push new AutoprefixLessPlugin autoprefixOptions
+
+addCleanCss = (options, optionsLess) =>
+    CleanCssLessPlugin = require 'less-plugin-clean-css'
+
+    cleancssOptions = {}
+    if typeof options == 'string'
+        cleancssOptions.compatibility = options
+
+    optionsLess.plugins.push new CleanCssLessPlugin cleancssOptions

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "async": "^0.9.0",
     "less": "^2.3.1",
+    "less-plugin-autoprefix": "^1.4.2",
+    "less-plugin-clean-css": "^1.5.0",
     "mkdirp": "^0.5.0"
   }
 }


### PR DESCRIPTION
Added support for the AutoPrefixer and CleanCSS plugins.

I took the idea from the Less Auto Compiler plugin for the Brackets editor, see [jdiehl/brackets-less-autocompile](https://github.com/jdiehl/brackets-less-autocompile), the [LessCompiler](https://github.com/jdiehl/brackets-less-autocompile/blob/master/node/LessCompiler.js).

The following is how they are used:
- **autoprefixer**: use autoprefixer (value is passed as browsers to the autoprefixer-plugin, separate multiple entires with a ; character)
- **cleancss**: use clean-css (value is passed as compatibility to the cleancss-plugin - not compatible with source-maps)

Thank you for a great plugin.
