### PR TITLE
Add parameter to compile with strict-math option

### DIFF
--- a/lib/less-autocompile-view.coffee
+++ b/lib/less-autocompile-view.coffee
@@ -71,6 +71,7 @@ class LessAutocompileView
       filename: path.basename params.file
       compress: if params.compress == 'true' then true else false
       sourceMap: if params.sourcemap == 'true' then {} else false
+      strictMath: if params.strictmath == 'true' then {} else false
 
     rl = readline.createInterface
       input: fs.createReadStream params.file


### PR DESCRIPTION
Parameter description with usage can be found on [the official less site](http://lesscss.org/usage/#command-line-usage-strict-math).
