### PR TITLE
Make the compile notifications dismissible

### DIFF
--- a/lib/less-autocompile-view.coffee
+++ b/lib/less-autocompile-view.coffee
@@ -48,10 +48,12 @@ class LessAutocompileView
       else
         if results.map != null
           atom.notifications.addSuccess "Files created",
-            detail: "#{results.css}\n#{results.map}"
+            detail: "#{results.css}\n#{results.map}",
+            dismissable: true
         else
           atom.notifications.addSuccess "File created",
-            detail: results.css
+            detail: results.css,
+            dismissable: true
 
   writeFile: (contentFile, newPath, newFile, callback) ->
     mkdirp newPath, (err) ->


### PR DESCRIPTION
It’s really annoying when I compile a LESS file and the notification lingers at the top of my screen for a couple of seconds, blocking my taps from being clickable. Now you should be able to dismiss the notifications.